### PR TITLE
[add] comment added to post model and password reset email fixed

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,10 +51,10 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.new(post_params)
-    # これはなぜ:postがある？
+    #:postはpostで投稿されてきた際にパラメーターとして飛ばされ、その中の[:tag_id]を取得して、splitで,区切りにしている
     tags = params[:post][:tag_id].split(',')
     if @post.save
-    # インスタンス変数をつける意味は？
+    #@postをつけることpostモデルの情報を.save_tagsに引き渡してメソッドを走らせることができる
       @post.save_tags(tags)
       redirect_to root_path, success: t('posts.create.create_success')
     else
@@ -69,11 +69,10 @@ class PostsController < ApplicationController
 
   def update
     @post = Post.find(params[:id])
-    # これはなぜ:postがある？
-    # :postパラメータの中のtag_idだけを取得している。
-    tags = params[:post][:tag_id].split(',')
+    #:postはpostで投稿されてきた際にパラメーターとして飛ばされ、その中の[:tag_id]を取得して、splitで,区切りにしている
+。  tags = params[:post][:tag_id].split(',')
     if @post.update(post_params)
-    # インスタンス変数をつける意味は？
+    #@postをつけることpostモデルの情報を.save_tagsに引き渡してメソッドを走らせることができる
       @post.update_tags(tags)
       redirect_to root_path, success: t('posts.edit.edit_success')
     else
@@ -83,7 +82,6 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
-    #dependentがだからしていしなくてもすべて削除される？
     post.destroy
     redirect_to root_path, success: t('posts.destroy.destroy_success')
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,8 +51,10 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.new(post_params)
+    # これはなぜ:postがある？
     tags = params[:post][:tag_id].split(',')
     if @post.save
+    # インスタンス変数をつける意味は？
       @post.save_tags(tags)
       redirect_to root_path, success: t('posts.create.create_success')
     else
@@ -67,8 +69,11 @@ class PostsController < ApplicationController
 
   def update
     @post = Post.find(params[:id])
+    # これはなぜ:postがある？
+    # :postパラメータの中のtag_idだけを取得している。
     tags = params[:post][:tag_id].split(',')
-    if @post.update_attributes(post_params)
+    if @post.update(post_params)
+    # インスタンス変数をつける意味は？
       @post.update_tags(tags)
       redirect_to root_path, success: t('posts.edit.edit_success')
     else
@@ -78,6 +83,7 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
+    #dependentがだからしていしなくてもすべて削除される？
     post.destroy
     redirect_to root_path, success: t('posts.destroy.destroy_success')
   end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -7,10 +7,12 @@ module NotificationsHelper
     # notification.actionがfollowかlikeかcommentか
     case notification.action
     when "follow"
+      #link_toと同じ
       tag.a(notification.visitor.nickname, href: friend_posts_path(@visitor), style: "font-weight: bold;") + t('notifications.index.followed_you')
     when "like"
       tag.a(notification.visitor.nickname, href: friend_posts_path(@visitor), style: "font-weight: bold;") + t('notifications.index.ga') + tag.a(t('notifications.index.your_comment'), href: post_path(notification.post_id), style: "font-weight: bold;") + t('notifications.index.ni_iine')
     when "comment" then
+      #投稿に基づくコメントを取り出してる.content
       @comment = Comment.find_by(id: @visitor_comment)&.content
       tag.a(@visitor.nickname, href: friend_posts_path(@visitor), style: "font-weight: bold;") +  t('notifications.index.ga2') + tag.a(t('notifications.index.your_comment2'), href: post_path(notification.post_id), style: "font-weight: bold;") + t('notifications.index.ni_iine2')
     end
@@ -18,7 +20,6 @@ module NotificationsHelper
   
   def unread_notifications
     # notificationテーブルでデフォルトでfalseが入っている
-    
     @notifications = current_user.reverse_notifications.where(checked: false)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -39,7 +39,6 @@ class Post < ApplicationRecord
   # タグ付けの新規投稿用メソッド
   def save_tags(tags)
     tags.each do |new_tags|
-      # selfは？
       # selfは明示的に記載していてこの場合だとコントローラーの@postになる
       # tag_relationshipsがthroughしているのでtagsでアソシエーションを指定すると中間テーブルを通過した際に保存される。
       self.tags.find_or_create_by(name: new_tags)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -39,35 +39,46 @@ class Post < ApplicationRecord
   # タグ付けの新規投稿用メソッド
   def save_tags(tags)
     tags.each do |new_tags|
+      # selfは？
+      # selfは明示的に記載していてこの場合だとコントローラーの@postになる
+      # tag_relationshipsがthroughしているのでtagsでアソシエーションを指定すると中間テーブルを通過した際に保存される。
       self.tags.find_or_create_by(name: new_tags)
     end
   end
 
   # タグ付けの更新用メソッド
   def update_tags(latest_tags)
-    if tags.empty?
+    if self.tags.empty?
       # 既存のタグがなかったら追加だけ行う
       latest_tags.each do |latest_tag|
-        tags.find_or_create_by(name: latest_tag)
+        self.tags.find_or_create_by(name: latest_tag)
       end
     elsif latest_tags.empty?
       # 更新対象のタグがなかったら既存のタグをすべて削除
-      tags.each do |tag|
-        tags.delete(tag)
+      # 既に保存がされていたら既に登録されているタグの内容を削除
+      self.tags.each do |tag|
+        self.tags.delete(tag)
       end
     else
       # 既存のタグも更新対象のタグもある場合は差分更新
-      current_tags = tags.pluck(:name)
+      current_tags = self.tags.pluck(:name)
+      #左を起点に引き算をする
+      #　　　　　　 b             a b c
       old_tags = current_tags - latest_tags
+      #一致したものを取り出す
+      # a c       a b c            b 
       new_tags = latest_tags - current_tags
 
+      # a  c
       old_tags.each do |old_tag|
-        tag = tags.find_by(name: old_tag)
-        tags.delete(tag) if tag.present?
+        tag = self.tags.find_by(name: old_tag)
+        self.tags.delete(tag) if tag.present?
       end
-
+      
+      
       new_tags.each do |new_tag|
-        tags.find_or_create_by(name: new_tag)
+        # b
+        self.tags.find_or_create_by(name: new_tag)
         # self.tags << new_tags
       end
     end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,11 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_user_password_url(@resource, reset_password_token: @token) %></p>
+<!--下記コメントアウトは古いパスワードリセットのリンクでパスワード再発行ができない-->
+<!--無効なトークのエラーが出たため、この記事を参考にした。https://github.com/next-l/enju_leaf/issues/1262-->
+<%#= link_to 'Change my password', edit_user_password_url(@resource, reset_password_token: @token) %>
+<%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token) %>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>
+

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,7 +16,7 @@
         <%= f.label :Password %><br/>
         <%= f.password_field :password, autocomplete: "current-password", class:"form-control" %>
       </div>
-      <div class="field text-center mt-2">  
+      <div class="field text-center mt-2">
         <%= render "devise/shared/links" %>
       </div>
       <div class="actions text-center mt-3">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,7 @@
                             <% if unread_notifications.any? %>
                             <!--ベルの色だけを金色に変えたい-->
                             <li class="nav-item">
+                            <!--link_toのnav-item-hoverは親関係なのでspanの子に反映されるはずだが反映されなかったので子にもbell-item-hoberを付与-->
                             <%= link_to notifications_path, class: "fas fa-bell nav-link mt-1  nav-item-hover", style: "color:gold;" do %>
                                 <span style="color: white" class="nav-item-hover"><%= t('application.application.notification') %></span>
                             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   
   # これをいれることでlocaleをパスに含められる
   # scopeを使用するとurlパターンのみを変更可能
-  scope '(:locale)' do  
+  # locale => /en|ja/ doと書かないとdeviseのパスワード再発行でi18nの影響でエラーになる
+  scope '(:locale)', :locale => /en|ja/ do  
     
     # postのindexをルートに設定
     root 'posts#index'


### PR DESCRIPTION
・パスワード再設定がlocaleをi18nをいれたことによりエラーが発生したため修正
　⇒ scopeのlocaleを修正、パスワード再設定の画面で無効なトークンですとエラーが出たため
　　メールで送られてくるパスワード再設定のリンクを修正したところ正常に動いた。